### PR TITLE
refactor: mover lógica de mapeamento para PokeApiMapper

### DIFF
--- a/PokemonApi.Infrastructure/Mappers/PokeApiMapper.cs
+++ b/PokemonApi.Infrastructure/Mappers/PokeApiMapper.cs
@@ -1,0 +1,25 @@
+﻿using PokemonApi.Domain.DTOs;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using PokemonApi.Infrastructure.Repositories;
+
+
+namespace PokemonApi.Infrastructure.Mappers
+{
+    public static class PokeApiMapper
+    {
+        public static PokemonDto ToPokemonDto(PokeApiResponse response)
+        {
+            return new PokemonDto
+            {
+                Name = response.Name,
+                Height = response.Height,
+                Weight = response.Weight,
+                Types = response.Types.Select(t => t.Type.Name).ToList()
+            };
+        }
+    }
+}

--- a/PokemonApi.Infrastructure/Repositories/PokeApiRepository.cs
+++ b/PokemonApi.Infrastructure/Repositories/PokeApiRepository.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using PokemonApi.Domain.DTOs;
 using PokemonApi.Domain.Exceptions;
 using PokemonApi.Domain.Repositories;
+using PokemonApi.Infrastructure.Mappers;
 using PokemonApi.Infrastructure.Repositories;
 
 
@@ -42,14 +43,14 @@ namespace PokemonApi.Infrastructure.Repositories
 
                 var pokeApiResponse = await response.Content.ReadFromJsonAsync<PokeApiResponse>();
 
-                //mapeia o json
-                return new PokemonDto
+                if (pokeApiResponse is null)
                 {
-                    Name = pokeApiResponse.Name,
-                    Height = pokeApiResponse.Height,
-                    Weight = pokeApiResponse.Weight,
-                    Types = pokeApiResponse.Types.Select(t => t.Type.Name).ToList()
-                };
+                    throw new ExternalServiceException("Resposta inválida da PokéAPI: não foi possível desserializar o conteúdo.");
+                }
+
+                return PokeApiMapper.ToPokemonDto(pokeApiResponse);
+
+
             }
             catch (HttpRequestException ex)
             {


### PR DESCRIPTION
Refatora o repositório responsável por consumir a PokéAPI, extraindo a lógica de mapeamento da resposta JSON para um mapper dedicado (PokeApiMapper).

Essa mudança segue o princípio de responsabilidade única, tornando o código mais limpo, modular e fácil de testar.

Não altera a resposta da API nem a interface pública dos serviços.